### PR TITLE
Add BLAZOR constant to ZoraSharp via Extra.targets

### DIFF
--- a/Extra.targets
+++ b/Extra.targets
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="3.5">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);BLAZOR;</DefineConstants>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This accompanies the changes I made to kabili207/zora-sharp#10. It moves the renamed BLAZOR define out into the newly created Extra.targets file that the ZoraSharp project looks for.